### PR TITLE
use cryptographically secure rng for passwords

### DIFF
--- a/lc_passgen/index.html
+++ b/lc_passgen/index.html
@@ -10,7 +10,7 @@ function randomLowercaseWord(numberOfWords,lengthOfWord) {
 	for (var i=0;i<numberOfWords;i++) {
 		var word="";
 		for (var j=0;j<lengthOfWord;j++) {
-			word=word.concat(String.fromCharCode(97 + shitty_cryptograpically_secure_random_int(25)));
+			word=word.concat(String.fromCharCode(97 + shitty_cryptograpically_secure_random_int(0,25)));
 		}
 		var newPassword = document.createElement('option');
 		newPassword.text=word;

--- a/lc_passgen/index.html
+++ b/lc_passgen/index.html
@@ -10,12 +10,38 @@ function randomLowercaseWord(numberOfWords,lengthOfWord) {
 	for (var i=0;i<numberOfWords;i++) {
 		var word="";
 		for (var j=0;j<lengthOfWord;j++) {
-			word=word.concat(String.fromCharCode(97 + Math.round(Math.random() * 25)));
+			word=word.concat(String.fromCharCode(97 + shitty_cryptograpically_secure_random_int(25)));
 		}
 		var newPassword = document.createElement('option');
 		newPassword.text=word;
 		selectObj.add(newPassword);
 	}
+}
+function shitty_cryptograpically_secure_random_int(min, max) {
+    if (min < 0 || min > 0xFFFF) {
+        throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+    }
+    if (max > 0xFFFF || max < 0) {
+        throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+    }
+    if (min > max) {
+        throw new Error("dude min>max wtf");
+    }
+    // micro-optimization (it does mage a huge relative difference, but on modern cpus...)
+    let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+    let ret;
+    let attempts = 0;
+    do {
+        crypto.getRandomValues(randArr);
+        ret = randArr[0];
+        ++attempts;
+        if (attempts > 999999) {
+            // should basically never happen with max 0xFFFF/Uint16Array. 
+	    // if you change it to Uint32Array or more, this may have a good chance of happening though.
+            throw new Error("tried a million times, soemthing is wrong");
+        }
+    } while (ret < min || ret > max);
+    return ret;
 }
 function selectPassword() {
 	var selectObj=document.getElementById("randomPasswordList");


### PR DESCRIPTION
the problem with using non-cryptograpically-secure rngs for generating passwords is that, 
if an attacker knows the dictionary used, and the generator used,
 then the attacker don't need to guess what password was generated, he can instead guess the initial state/seed of the rng, 
to re-generate the actual password.

to protect against this kind of attack, a cryptographically secure rng should be used. Math.random() is not cs-secure.
quoting https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random :  
Note: Math.random() does not provide cryptographically secure random numbers. Do not use them for anything related to security. Use the Web Crypto API instead, and more precisely the window.crypto.getRandomValues() method.

PS this code is not compatible with IE10 or older (should work on IE11+ though, not tested..)